### PR TITLE
Add indices and selection order

### DIFF
--- a/src/AssetsSelector.tsx
+++ b/src/AssetsSelector.tsx
@@ -127,13 +127,15 @@ const AssetsSelector = ({
 
     const onClickUseCallBack = useCallback((id: string) => {
         setSelectedItems(selectedItems => {
-            if (selectedItems.length >= maxSelections)
+            const alreadySelected = selectedItems.indexOf(id) >= 0;
+
+            if (selectedItems.length >= maxSelections && !alreadySelected)
                 return selectedItems
 
-            if (selectedItems.indexOf(id) === -1)
-                return [...selectedItems, id];
-            else
+            if (alreadySelected)
                 return selectedItems.filter(item => item !== id);
+            else
+                return [...selectedItems, id];
         })
     }, [])
 

--- a/src/AssetsSelectorList.tsx
+++ b/src/AssetsSelectorList.tsx
@@ -9,7 +9,7 @@ const Item = ({
     id,
     screen,
     cols,
-    selected,
+    selectedIndex,
     image,
     mediaType,
     onClick,
@@ -48,10 +48,15 @@ const Item = ({
                     )}
                 </MediaTypeVideo>
             )}
-            {selected && (
+            {selectedIndex >= 0 && (
                 <Selected selectionColor={bg} margin={margin}>
                     {Component && (
-                        <Component name={iconName} size={size} color={color} />
+                        <Component
+                          name={iconName}
+                          size={size}
+                          color={color}
+                          index={selectedIndex}
+                        />
                     )}
                 </Selected>
             )}
@@ -83,7 +88,7 @@ export const AssetsSelectorList = ({
             id={item.id}
             image={item.uri}
             mediaType={item.mediaType}
-            selected={selectedItems.has(item.id)}
+            selectedIndex={selectedItems.indexOf(item.id)}
             onClick={onClick}
             cols={cols}
             screen={screen}

--- a/src/AssetsSelectorTypes.ts
+++ b/src/AssetsSelectorTypes.ts
@@ -19,7 +19,7 @@ export interface IComponentItem {
     screen: number
     image: string
     margin: number
-    selected: boolean
+    selectedIndex: number
     onClick: (id: string) => void
     mediaType: MediaTypeValue
     selectedIcon: SelectedIcon
@@ -103,7 +103,7 @@ export type IComponentItems = {
     margin: number
     cols: number
     screen: number
-    selectedItems: Set<string>
+    selectedItems: string[]
     onClick: (id: string) => void
     getMoreAssets: () => void
     selectedIcon: SelectedIcon


### PR DESCRIPTION
Thank you for this package. I pushed a little enhancement...

The main idea is to keep an order of selected items. Plus, add an ability to display item numbers (see test screenshot below).
The output data is still the same, but the result will now respect the selection order.
Tried to follow the code style in the project. And also, not used `arr.includes`, because in `tsconfig`: `"target": "es5"`, so stick to old-fashioned `arr.indexOf`.
Maybe, could use `{ List } from 'immutable'`, but usually I just prefer to control it manually and use only immutable functions with state variables

![image](https://user-images.githubusercontent.com/5086053/97065920-f24b0f00-157e-11eb-97bb-2dbc7a7891c5.png)
