### PR TITLE
Expo 41 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/natysoz/expo-images-picker#readme",
   "peerDependencies": {
     "react": "*",
-    "expo": "^40.0.0",
+    "expo": ">=40.0.0",
     "react-native": "*"
   },
   "dependencies": {


### PR DESCRIPTION
Expo 41 was recently released, but the peer dependency (`^40.0.0`) doesn't allow to use it.