### PR TITLE
Fix dependency for Expo 41 & removed deprecated expo-permissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/natysoz/expo-images-picker#readme",
   "peerDependencies": {
     "react": "*",
-    "expo": "^40.0.0",
+    "expo": "^41.0.0",
     "react-native": "*"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "expo-image-manipulator": "^9.0.0",
     "expo-media-library": "~10.0.0",
-    "expo-permissions": "~10.0.0",
+    "expo-permissions": "^11.0.0",
     "styled-components": "^5.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "expo-image-manipulator": "^9.0.0",
     "expo-media-library": "~10.0.0",
-    "expo-permissions": "^11.0.0",
+    "expo-permissions": "~10.0.0",
     "styled-components": "^5.1.1"
   },
   "devDependencies": {

--- a/src/AssetsSelector.tsx
+++ b/src/AssetsSelector.tsx
@@ -139,8 +139,13 @@ const AssetsSelector = ({
     )
 
     const getCameraPermissions = useCallback(async () => {
-        const { status: CAMERA }: any = await Permissions.askAsync("camera");
-        const { status: CAMERA_ROLL }: any = await Permissions.askAsync("cameraRoll");
+        const { status: CAMERA }: any = await Permissions.askAsync(
+            Permissions.CAMERA
+        )
+
+        const { status: CAMERA_ROLL }: any = await Permissions.askAsync(
+            Permissions.MEDIA_LIBRARY
+        )
 
         setPermissions({
             hasCameraPermission: CAMERA === 'granted',

--- a/src/AssetsSelector.tsx
+++ b/src/AssetsSelector.tsx
@@ -139,13 +139,8 @@ const AssetsSelector = ({
     )
 
     const getCameraPermissions = useCallback(async () => {
-        const { status: CAMERA }: any = await Permissions.askAsync(
-            Permissions.CAMERA
-        )
-
-        const { status: CAMERA_ROLL }: any = await Permissions.askAsync(
-            Permissions.MEDIA_LIBRARY
-        )
+        const { status: CAMERA }: any = await Permissions.askAsync("camera");
+        const { status: CAMERA_ROLL }: any = await Permissions.askAsync("cameraRoll");
 
         setPermissions({
             hasCameraPermission: CAMERA === 'granted',


### PR DESCRIPTION
Hi natysoz,

I have added support for expo 41 in package.json.

I also modified the permissions, because expo-permissions is deprecated:
https://docs.expo.io/versions/latest/sdk/permissions/

It is suggested to use the request permission function directly in expo-media-library

Thanks!