### PR TITLE
Add on change prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-images-picker",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Expo images picker, Selecting Multiple images and videos from user device",
   "main": "index.ts",
   "repository": {

--- a/src/AssetsSelector.tsx
+++ b/src/AssetsSelector.tsx
@@ -30,6 +30,7 @@ const AssetsSelector = ({
     Styles,
     Navigator,
     CustomNavigator,
+    onChange
 }: AssetSelectorPropTypes): JSX.Element => {
     const getScreen = () => Dimensions.get('screen')
 
@@ -53,6 +54,12 @@ const AssetsSelector = ({
     })
 
     const [assetItems, setItems] = useState<Asset[]>([])
+
+    useEffect(() => {
+        if (typeof onChange === 'function') {
+            onChange(assetItems)
+        }
+    }, [assetItems])
 
     const [isLoading, setLoading] = useState(true)
 

--- a/src/AssetsSelector.tsx
+++ b/src/AssetsSelector.tsx
@@ -57,9 +57,15 @@ const AssetsSelector = ({
 
     useEffect(() => {
         if (typeof onChange === 'function') {
-            onChange(assetItems)
+            onChange(
+                selectedItems.map((id, index) => {
+                    const asset = assetItems.find((item) => item.id === id)
+                    if (!asset) throw new Error(`Invalid asset at index ${index}`)
+                    return asset
+                })
+            )
         }
-    }, [assetItems])
+    }, [selectedItems, assetItems])
 
     const [isLoading, setLoading] = useState(true)
 

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -11,6 +11,7 @@ export type AssetSelectorPropTypes = {
     Navigator?: NavigatorType
     Resize?: ResizeType
     CustomNavigator?: CustomNavigator
+    onChange?: (data?: any) => void
 }
 
 export type ResizeType = {

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -11,7 +11,7 @@ export type AssetSelectorPropTypes = {
     Navigator?: NavigatorType
     Resize?: ResizeType
     CustomNavigator?: CustomNavigator
-    onChange?: (data?: any) => void
+    onChange?: (selectedItems: Array<Asset>) => void
 }
 
 export type ResizeType = {


### PR DESCRIPTION
This pull request adds an `onChange` prop which can be used to hoist the selected items state

resolves: https://github.com/natysoz/expo-images-picker/issues/36