### PR TITLE
Return always a value in function to satisfy 'noImplicitReturns' rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,8 @@ size: 22}`
 
 ### 🐛 Bug fixes
 -----------------------------------------
+#### 2.2.3 - 2021-08-11
+- fix Compile error with typescript 
 
 #### 2.2.2 — 2021-05-11
 - fix Compile error with the latest PR.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-images-picker",
-  "version": "2.2.1",
+  "version": "2.2.3",
   "description": "Expo images picker, Selecting Multiple images and videos from user device",
   "main": "index.ts",
   "repository": {

--- a/src/AssetsSelector.tsx
+++ b/src/AssetsSelector.tsx
@@ -159,7 +159,7 @@ const AssetsSelector = ({
                 errorType: 'hasErrorWithLoading',
             })
         }
-        else return // only added because of `noImplicitReturns` ugly rule.
+        return; // only added because of `noImplicitReturns` ugly rule.
     }
 
     const resizeImages = async (image: Asset, manipulate: ResizeType) => {

--- a/src/AssetsSelector.tsx
+++ b/src/AssetsSelector.tsx
@@ -152,13 +152,14 @@ const AssetsSelector = ({
                 return permissions.hasMediaLibraryPermission
                     ? loadAssets(params)
                     : getMediaLibraryPermission()
-            } else return // only added because of `noImplicitReturns` ugly rule.
+            } 
         } catch (err) {
             setError({
                 hasError: true,
                 errorType: 'hasErrorWithLoading',
             })
         }
+        else return // only added because of `noImplicitReturns` ugly rule.
     }
 
     const resizeImages = async (image: Asset, manipulate: ResizeType) => {


### PR DESCRIPTION
In case of an error the catch block will be executed but doesn't return any value.
Using a fall through return at the end of the function satisfies the rule of 'noImplicitReturns'.