### PR TITLE
update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "react-native": "*"
   },
   "dependencies": {
-    "expo-image-manipulator": "~10.2.1",
-    "expo-media-library": "~14.0.1",
-    "styled-components": "^5.3.0"
+    "expo-image-manipulator": "~10.2.0",
+    "expo-media-library": "~14.0.0",
+    "styled-components": "^5.2.3"
   },
   "devDependencies": {
     "@types/styled-components": "^5.1.11",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "react-native": "*"
   },
   "dependencies": {
-    "expo-image-manipulator": "~10.1.2",
-    "expo-media-library": "~13.0.3",
+    "expo-image-manipulator": "~10.2.1",
+    "expo-media-library": "~14.0.1",
     "styled-components": "^5.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
expo-media-library was using an outdated version of expo-modules-core therefore my build with eas and expo 44 was failing