### PR TITLE
features: 1) scale image along dominant axis and 2) support existing selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ use useMemo from react.
             assetsType: [MediaType.photo, MediaType.video],
             minSelection: 1,
             maxSelection: 3,
+            existingSelectionIds: ["<selected Id 1>", "<selected Id 2>", "<selected Id N>"],
             portraitCols: 4,
             landscapeCols: 4,
         }),
@@ -113,6 +114,9 @@ use useMemo from react.
 
 
 - `maxSelection` - max amount of images user need to select.
+
+
+- `existingSelectionIds` - array that includes the id's of those assets previously selected. Each value comes from the Asset in onSuccess callback. `optional`
 
 
 - `portraitCols` - Number of columns in portrait Mode.
@@ -282,20 +286,44 @@ use useMemo from react.
 ### CustomNavigator :
 
 Make sure your CustomTopNavigator can receive onSuccess function.
-And bind this onFinish function on the correct button.
+And bind this onFinish function on the correct button. This is useful for
+integrating with React Navigation header.
 
 - `Component` - Send in your Custom nav bar.
 
 - `props` Send any props your Custom Component needs.
 
+Example with React Navigation
+
 ```js
+type CustomNavImageSelectionProps = {
+  navigation: CustomNavigationProp
+  onSuccess: () => void
+  backFunction: boolean
+  text: string
+};
+
+function CustomNavImageSelection({ navigation, onSuccess, backFunction, text }: CustomNavImageSelectionProps) {
+  useEffect(() => {
+    navigation.setOptions({
+      headerRight: () => <Button title={text} onPress={onSuccess} />,
+    })
+  }, [navigation, onSuccess, text])
+
+  return null
+}
+
 <AssetsSelector
   options={{
     ...otherProps,
     CustomTopNavigator: {
       Component: CustomNavImageSelection,
       props: {
-        onSuccess: (data: Asset[]) => onDone(data),
+        navigation,
+        onSuccess: (data: Asset[]) => {
+            onDone(data)
+            navigation.goBack()
+        },
         backFunction: true,
         text: T.ACTIONS.SELECT
       },

--- a/README.md
+++ b/README.md
@@ -253,6 +253,8 @@ use useMemo from react.
     const widgetResize = useMemo(
         () => ({
             width: 512,
+            height: 384,
+            majorAxis: 512,
             compress: 0.7,
             base64: false,
             saveTo: SaveType.JPG,
@@ -267,6 +269,8 @@ use useMemo from react.
 - `width` - Manipulate image width `optional`
 
 - `height` - Manipulate image width `optional`
+
+- `majorAxis` - Manipulate image's major axis only (if width and height are not specified) `optional`
 
 - `compress` - compress 0.1 Super low quality 1.0 leave as is (high quality).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-images-picker",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "description": "Expo images picker, Selecting Multiple images and videos from user device",
   "main": "index.ts",
   "repository": {

--- a/src/AssetsSelector.tsx
+++ b/src/AssetsSelector.tsx
@@ -81,6 +81,15 @@ const AssetsSelector = ({
                         after: endCursor,
                         hasNextPage: hasNextPage,
                     })
+                    if (Settings.existingSelectionIds) {
+                        const selected: string[] = []
+                        for (let i = 0; i < assets.length; i++) {
+                            if (Settings.existingSelectionIds.includes(assets[i].id)) {
+                                selected.push(assets[i].id)
+                            }
+                        }
+                        setSelectedItems([...selected])
+                    }
                     setLoading(false)
                     return setItems([...assetItems, ...assets])
                 })
@@ -225,7 +234,7 @@ const AssetsSelector = ({
                         selectedItems.indexOf(a.id) -
                         selectedItems.indexOf(b.id)
                 ),
-        [selectedItems]
+        [assetItems, selectedItems]
     )
 
     const manipulateResults = async (source: string) => {
@@ -242,13 +251,14 @@ const AssetsSelector = ({
             }
             if (Resize) {
                 let modAssets: (ImageManipulator.ImageResult &
-                    Pick<MediaLibrary.Asset, 'mediaType'>)[] = []
+                    Pick<MediaLibrary.Asset, 'mediaType' | 'id'>)[] = []
                 await asyncForEach(selectedAssets, async (asset: Asset) => {
                     if (asset.mediaType === 'photo') {
                         const resizedImage = await resizeImages(asset, Resize)
                         modAssets.push({
                             ...resizedImage,
                             mediaType: asset.mediaType,
+                            id: asset.id
                         })
                     } else modAssets.push(asset)
                 })

--- a/src/AssetsSelector.tsx
+++ b/src/AssetsSelector.tsx
@@ -184,7 +184,7 @@ const AssetsSelector = ({
                 sizeOptions.height = image.height
             }
 
-            if (majorAxis) {
+            if (majorAxis && !width && !height) {
                 if (image.width > image.height)
                     sizeOptions.width = majorAxis
                 else sizeOptions.height = majorAxis

--- a/src/AssetsSelector.tsx
+++ b/src/AssetsSelector.tsx
@@ -164,7 +164,7 @@ const AssetsSelector = ({
 
     const resizeImages = async (image: Asset, manipulate: ResizeType) => {
         try {
-            const { base64, width, height, saveTo, compress } = manipulate
+            const { base64, width, height, majorAxis, saveTo, compress } = manipulate
             const saveFormat = saveTo
                 ? saveTo === 'jpeg'
                     ? ImageManipulator.SaveFormat.JPEG
@@ -179,9 +179,15 @@ const AssetsSelector = ({
                 height,
             }
 
-            if (!width && !height) {
+            if (!majorAxis && !width && !height) {
                 sizeOptions.width = image.width
                 sizeOptions.height = image.height
+            }
+
+            if (majorAxis) {
+                if (image.width > image.height)
+                    sizeOptions.width = majorAxis
+                else sizeOptions.height = majorAxis
             }
             const options = [
                 {

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -32,6 +32,7 @@ export type SettingsType = {
     assetsType: MediaTypeValue[]
     minSelection: number
     maxSelection: number
+    existingSelectionIds?: string[]
     portraitCols: number
     landscapeCols: number
     getImageMetaData: boolean

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -16,6 +16,7 @@ export type AssetSelectorPropTypes = {
 export type ResizeType = {
     width?: number
     height?: number
+    majorAxis?: number
     compress?: number
     base64: boolean
     saveTo?: string


### PR DESCRIPTION
I have added 2 new features to the package and improved the documentation using CustomNavigator (because I had to read the code to understand how it worked).

First feature - resize the image based on its dominant axis.

I would like to change image size but rather than choose width or height, I will let the image size decide based on its dominant axis. Currently, if width set to 1024, and the image is portrait, the result will be 1024 x some number > 1024. If the image is landscape, the result will be 1024 x some number < 1024. This change ensures that 1024 will be applied to the largest dimension, thus the other dimension will always be smaller.

Second feature - select items that were previously selected.

The Settings optionally takes an array of items already selected and AssetsSelector selects those items (assuming they are found). The items are identified based on Asset.id. The client is responsible for saving the ids and passing them in on subsequent calls. It's common users will change their selection and they should be able to pick up where they left off instead of starting over.
